### PR TITLE
TS fixes to comply with v4.8 and above

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ test.js
 *.js
 *.d.ts
 
-!prettierrc.js
+!.prettierrc.js
 
 # production
 /build

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  singleQuote: true,
+  semi: false,
+  trailingComma: 'all',
+  printWidth: 120,
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-query",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "author": "Kyle Bebak <kylebebak@gmail.com>",
   "description": "React hooks and functions for SWR-style data fetching, backed by Redux",
   "main": "./index.js",

--- a/reducer.ts
+++ b/reducer.ts
@@ -30,7 +30,9 @@ export default function reduce(state: QueryBranch = {}, action: Action): QueryBr
     }
 
     case 'REACT_REDUX_QUERY_UPDATE_DATA': {
-      const { key, updater, newData } = action.payload as Update<{}> & { newData: {} }
+      const { key, updater, newData } = action.payload as Update<{}> & {
+        newData: {}
+      }
 
       const data = (updater as NonNullable<QueryOptions<{}>['updater']>)(state[key]?.data, newData)
       if (data === undefined) return state

--- a/test.ts
+++ b/test.ts
@@ -7,7 +7,13 @@ import { save, update } from './actions'
 import reduce from './reducer'
 
 test('save reducer', async (t) => {
-  const newState = reduce({}, { type: 'REACT_REDUX_QUERY_SAVE_DATA', payload: { key: 'res', data: { data: true } } })
+  const newState = reduce(
+    {},
+    {
+      type: 'REACT_REDUX_QUERY_SAVE_DATA',
+      payload: { key: 'res', data: { data: true } },
+    },
+  )
 
   t.is(newState.res?.data?.data, true)
 })
@@ -15,7 +21,10 @@ test('save reducer', async (t) => {
 test('save action creator', async (t) => {
   const action = save({ key: 'res', data: {} })
 
-  t.deepEqual(action, { type: 'REACT_REDUX_QUERY_SAVE_DATA', payload: { key: 'res', data: {} } })
+  t.deepEqual(action, {
+    type: 'REACT_REDUX_QUERY_SAVE_DATA',
+    payload: { key: 'res', data: {} },
+  })
 })
 
 test('update reducer', async (t) => {


### PR DESCRIPTION
- Add missing `.prettierrc.js` config file and run prettier with that file.
  - The `.prettierrc.js` file was created based on the one from `request.js` repo.
- Typescript fixes to comply with v4.8 and above, fixing this [breaking change](https://github.com/microsoft/TypeScript/wiki/Breaking-Changes#typescript-48)
  - Basically we just need to narrow down some types with `extends {}` as "Unconstrained type parameters" are no longer assign by default to `{}`
  
We are not updating the TS version of this repo, but with this change, it will comply with recent TS versions while being compatible with the current TS version.